### PR TITLE
Fix most Code Climate and Rubocop offenses

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,6 +14,7 @@ engines:
       - javascript
     exclude_paths:
     - 'spec/**/*'
+    - 'db/schema.rb'
   eslint:
     enabled: true
   fixme:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
     - '**/Rakefile'
   Exclude:
     - 'bin/**/*'
+    - 'db/schema.rb'
   UseCache: true
 
 Metrics/AbcSize:

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,13 +2,13 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   skip_before_action :verify_authenticity_token
 
   def saml
-    @user = User.from_omniauth(request.env["omniauth.auth"])
+    @user = User.from_omniauth(request.env['omniauth.auth'])
 
     if @user.persisted?
-      sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
-      set_flash_message(:notice, :success, :kind => "IdP") if is_navigational_format?
+      sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
+      set_flash_message(:notice, :success, kind: 'IdP') if is_navigational_format?
     else
-      session["devise.saml_data"] = request.env["omniauth.auth"]
+      session['devise.saml_data'] = request.env['omniauth.auth']
       redirect_to new_user_registration_url
       flash[:error] = 'Sorry, we could not authenticate you. Please try again later.'
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,12 +4,12 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  devise :omniauthable, :omniauth_providers => [:saml]
+  devise :omniauthable, omniauth_providers: [:saml]
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.email = auth.info.email
-      user.password = Devise.friendly_token[0,20]
+      user.password = Devise.friendly_token[0, 20]
       user.name = auth.info.name
     end
   end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -5,7 +5,7 @@ require 'rails/commands/server'
 
 module DefaultOptions
   def default_options
-    super.merge!(Port:3003)
+    super.merge!(Port: 3003)
   end
 end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -26,18 +26,18 @@ Devise.setup do |config|
   config.sign_out_via = :delete
 
   config.omniauth :saml,
-                  :assertion_consumer_service_url     => "http://localhost:3003/users/auth/saml/callback",
-                  :assertion_consumer_service_binding => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                  :issuer                             => Rails.application.secrets.saml_issuer,
-                  :idp_sso_target_url                 => Rails.application.secrets.idp_url,
-                  :idp_cert                           => File.read("#{Rails.root}/certs/saml.crt"),
-                  :name_identifier_format             => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-                  :authn_context                      => "http://idmanagement.gov/ns/assurance/loa/1",
-                  :allowed_clock_drift                => 60,
-                  :certificate                        => File.read("#{Rails.root}/certs/sp/demo_sp.crt"),
-                  :private_key                        => File.read("#{Rails.root}/keys/saml_test_sp.key"),
-                  :security                           => {:authn_requests_signed => true,
-                                                          :embed_sign            => true,
-                                                          :digest_method         => "http://www.w3.org/2001/04/xmlenc#sha256",
-                                                          :signature_method      => "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"}
+                  assertion_consumer_service_url: 'http://localhost:3003/users/auth/saml/callback',
+                  assertion_consumer_service_binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+                  issuer: Rails.application.secrets.saml_issuer,
+                  idp_sso_target_url: Rails.application.secrets.idp_url,
+                  idp_cert: File.read("#{Rails.root}/certs/saml.crt"),
+                  name_identifier_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+                  authn_context: 'http://idmanagement.gov/ns/assurance/loa/1',
+                  allowed_clock_drift: 60,
+                  certificate: File.read("#{Rails.root}/certs/sp/demo_sp.crt"),
+                  private_key: File.read("#{Rails.root}/keys/saml_test_sp.key"),
+                  security: { authn_requests_signed: true,
+                              embed_sign: true,
+                              digest_method: 'http://www.w3.org/2001/04/xmlenc#sha256',
+                              signature_method: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256' }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root 'home#index'
 
-  devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 end

--- a/db/migrate/20160602162432_add_devise_to_users.rb
+++ b/db/migrate/20160602162432_add_devise_to_users.rb
@@ -2,8 +2,8 @@ class AddDeviseToUsers < ActiveRecord::Migration
   def self.up
     change_table :users do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string :email,              null: false, default: ''
+      t.string :encrypted_password, null: false, default: ''
 
       ## Recoverable
       t.string   :reset_password_token
@@ -29,7 +29,6 @@ class AddDeviseToUsers < ActiveRecord::Migration
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
-
 
       # Uncomment below if timestamps were not included in your original model.
       # t.timestamps null: false

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe HomeController, type: :controller do
-
-  describe "GET #index" do
-    it "returns http success" do
+  describe 'GET #index' do
+    it 'returns http success' do
       get :index
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,16 +13,14 @@ RSpec.describe User, type: :model do
       end
 
       it 'finds a user if they exist and leaves the email, name alone' do
-        auth = OmniAuth::AuthHash.new({
-          provider: 'test_provider',
-          uid: 'test_uid',
-          info: {
-            email: 'new_email@example.com',
-            name: 'Name McNameface'
-          }
-        })
+        auth = OmniAuth::AuthHash.new(provider: 'test_provider',
+                                      uid: 'test_uid',
+                                      info: {
+                                        email: 'new_email@example.com',
+                                        name: 'Name McNameface'
+                                      })
         user = nil
-        expect{user = User.from_omniauth(auth)}.to change{User.all.count}.by(0)
+        expect { user = User.from_omniauth(auth) }.to change { User.all.count }.by(0)
         expect(user.email).to eq(@user.email)
         expect(user.name).to eq(@user.name)
       end
@@ -30,16 +28,14 @@ RSpec.describe User, type: :model do
 
     describe 'for a new user' do
       it 'creates a user if they do not exist' do
-        auth = OmniAuth::AuthHash.new({
-                                        provider: 'test_provider',
-                                        uid: 'test_uid',
-                                        info: {
-                                          email: 'new_email@example.com',
-                                          name: 'Name McNameface'
-                                        }
+        auth = OmniAuth::AuthHash.new(provider: 'test_provider',
+                                      uid: 'test_uid',
+                                      info: {
+                                        email: 'new_email@example.com',
+                                        name: 'Name McNameface'
                                       })
         user = nil
-        expect{user = User.from_omniauth(auth)}.to change{User.all.count}.by(1)
+        expect { user = User.from_omniauth(auth) }.to change { User.all.count }.by(1)
         expect(user.email).to eq(auth.info.email)
         expect(user.name).to eq(auth.info.name)
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
@@ -27,7 +27,7 @@ require 'rspec/rails'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  config.include Devise::TestHelpers, :type => :controller
+  config.include Devise::TestHelpers, type: :controller
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,53 +40,51 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # These two settings work together to allow you to limit a spec run
-  # to individual examples or groups you care about by tagging them with
-  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
-  # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # These two settings work together to allow you to limit a spec run
+  #   # to individual examples or groups you care about by tagging them with
+  #   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
+  #   # get run.
+  #   config.filter_run :focus
+  #   config.run_all_when_everything_filtered = true
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = 'doc'
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
**Why**: To fix issues that weren't caught before we enabled Code Climate. The remaining offenses will be fixed in a separate PR that removes Devise.